### PR TITLE
Fix issue with Vundle plugins

### DIFF
--- a/src/4_programming_languages/write_c.md
+++ b/src/4_programming_languages/write_c.md
@@ -63,8 +63,7 @@ Before the line: `" All of your Plugins must be added before the following line`
 Add the following:
 
 ```
-Plugin 'valloric/youcompleteme'
-Plugin 'VundleVim/Vundle.vim'
+Plugin 'Valloric/YouCompleteMe'
 Plugin 'airblade/vim-gitgutter'
 Plugin 'editorconfig/editorconfig-vim'
 Plugin 'itchyny/lightline.vim'


### PR DESCRIPTION
If Valloric/YouCompleteMe plugin is typed all in lowercase it causes the installation to fail when compiling.  It is now unnecessary to include Plugin 'VundleVim/Vundle.vim' and causes duplication error if it is included.